### PR TITLE
Use renamed repo everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ sudo yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-
 sudo yum update -y nss curl libcurl
 sudo yum install -y screen postgresql13
 sudo yum groupinstall -y "Development tools"
-git clone https://github.com/citusdata/ch-benchmark.git
-cd ch-benchmark
+git clone https://github.com/citusdata/citus-benchmark.git
+cd citus-benchmark
 ```
 
 If you are using Ubuntu / Debian on the driver node:
@@ -26,8 +26,8 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-
 echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |sudo tee  /etc/apt/sources.list.d/pgdg.list
 sudo apt update -y
 sudo apt install -y postgresql-client-13
-git clone https://github.com/citusdata/ch-benchmark.git
-cd ch-benchmark
+git clone https://github.com/citusdata/citus-benchmark.git
+cd citus-benchmark
 ```
 
 # Running HammerDB TPROC-C with CH-benCHmark support

--- a/azure/driver-vm.bicep
+++ b/azure/driver-vm.bicep
@@ -72,8 +72,8 @@ cat >> .bashrc << '__ssh_connection_bashrc__'
 __ssh_connection_bashrc__
 
 sudo apt-get install -y postgresql-client-{4}
-git clone https://github.com/citusdata/ch-benchmark.git
-cd ch-benchmark
+git clone https://github.com/citusdata/citus-benchmark.git
+cd citus-benchmark
 
 {5}
 

--- a/azure/get-results.sh
+++ b/azure/get-results.sh
@@ -11,4 +11,4 @@ ssh -o "UserKnownHostsFile=/dev/null" \
     -o "ControlPath=.ssh-controlmasters/%r@%h:%p" \
     -o "ControlPersist=24h" \
     "$ip" \
-    "ch-benchmark/create-csv-result-lines.sh"
+    "citus-benchmark/create-csv-result-lines.sh"


### PR DESCRIPTION
We renamed the repo to citus-benchmark, but were still using the old
name in various places.