### PR TITLE
Use PG15 as default

### DIFF
--- a/azure/hyperscale-pre-created.bicep
+++ b/azure/hyperscale-pre-created.bicep
@@ -21,7 +21,7 @@ param timeprofile bool = true
 
 
 // Configuration of the postgres server group
-param pgVersion string = '14'
+param pgVersion string = '15'
 
 // Configuration of the VM that runs the benchmark (the driver)
 // This VM should be pretty big, to make sure it does not become the bottleneck

--- a/azure/hyperscale.bicep
+++ b/azure/hyperscale.bicep
@@ -19,7 +19,7 @@ param timeprofile bool = true
 
 
 // Configuration of the postgres server group
-param pgVersion string = '14'
+param pgVersion string = '15'
 param coordinatorVcores int = 8
 param coordinatorStorageSizeMB int = 524288 // 512GB
 param workers int = 2

--- a/azure/iaas-postgres.bicep
+++ b/azure/iaas-postgres.bicep
@@ -19,7 +19,7 @@ param rampup int = 3
 param timeprofile bool = true
 
 // Configuration of the postgres server
-param pgVersion string = '14'
+param pgVersion string = '15'
 param pgSize string  = 'Standard_D8s_v3'
 param pgStorageSizeGB int = 512
 param pgConfigOptions string = ''
@@ -78,7 +78,7 @@ mkfs.xfs /dev/disk/azure/scsi1/lun0
 mkdir /datadrive
 mount /dev/disk/azure/scsi1/lun0 /datadrive
 
-mv /var/lib/postgresql/14/main/ /datadrive/pgdata
+mv /var/lib/postgresql/15/main/ /datadrive/pgdata
 
 cat >> /etc/postgresql/{0}/main/postgresql.conf << '__postgres_conf_EOF__'
 {1}


### PR DESCRIPTION
https://github.com/citusdata/citus-benchmark/pull/18 is already approved but there is a slight issue when retrieving NOPM at the end with the new HammerDB version. Hence opening a separate PR just for PG default version.